### PR TITLE
Add tag rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,21 @@ bower install html-janitor
 # or
 npm install html-janitor
 ```
+
+## Usage
+
+```javascript
+require(['html-janitor'], function (HTMLJanitor) {
+  var div = document.querySelector('.myDiv');
+  var janitor = new HTMLJanitor({
+    // Only listed tags will be allowed
+    tags: {
+      // Allow any href and target="_blank" on <a>:
+      a: { href: true, target: '_blank' },
+      // Rewrite h2 to h1:
+      h2: 'h1'
+    }
+  });
+  console.log(janitor.clean(div.outerHTML));
+});
+```

--- a/test/janitor.spec.js
+++ b/test/janitor.spec.js
@@ -6,8 +6,11 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
       tags: {
         b: {},
         p: { foo: true, bar: 'baz' },
+        ol: 'ul',
         ul: {},
-        li: {}
+        li: {},
+        h1: { doge: 'wow' },
+        h2: 'h1'
       }
 
 
@@ -36,6 +39,20 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
       var p = document.createElement('p');
       div.appendChild(p);
       expect(janitor.clean(div.outerHTML)).toBe('<p></p>');
+    });
+
+    it('should rewrite tag names', function () {
+      var ol = document.createElement('ol');
+      var li = document.createElement('li');
+      li.innerText = 'Hello';
+      ol.appendChild(li);
+      expect(janitor.clean(ol.outerHTML)).toBe('<ul><li>Hello</li></ul>');
+    });
+
+    it('should consider target element rules when rewriting tag names', function () {
+      var h2 = document.createElement('h2');
+      h2.setAttribute('doge', 'wow');
+      expect(janitor.clean(h2.outerHTML)).toBe('<h1 doge="wow"></h1>');
     });
 
     it('should not keep the inner text of a script element', function () {


### PR DESCRIPTION
This is useful in case you'd like to rewrite some tags as you strip them.

For example, you might want to make headings of one type instead of completely stripping them.
Or you might want to only support bullet lists.