### PR TITLE
Allow for catch-all whitelist on a tag name

### DIFF
--- a/src/html-janitor.js
+++ b/src/html-janitor.js
@@ -111,7 +111,7 @@
         var attrName = attr.name.toLowerCase();
 
         // Allow attribute?
-        var allowedAttrValue = allowedAttrs[attrName] || allowedAttrs;
+        var allowedAttrValue = allowedAttrs[attrName] || allowedAttrs === true;
         var notInAttrList = ! allowedAttrValue;
         var valueNotAllowed = allowedAttrValue !== true && attr.value !== allowedAttrValue;
         if (notInAttrList || valueNotAllowed) {

--- a/src/html-janitor.js
+++ b/src/html-janitor.js
@@ -104,7 +104,7 @@
         var attrName = attr.name.toLowerCase();
 
         // Allow attribute?
-        var allowedAttrValue = allowedAttrs[attrName];
+        var allowedAttrValue = allowedAttrs[attrName] || allowedAttrs;
         var notInAttrList = ! allowedAttrValue;
         var valueNotAllowed = allowedAttrValue !== true && attr.value !== allowedAttrValue;
         if (notInAttrList || valueNotAllowed) {

--- a/test/janitor.spec.js
+++ b/test/janitor.spec.js
@@ -7,7 +7,8 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
         b: {},
         p: { foo: true, bar: 'baz' },
         ul: {},
-        li: {}
+        li: {},
+        span: true
       }
 
 
@@ -29,6 +30,13 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
       p.setAttribute('foo', 'true');
       p.setAttribute('bar', 'baz');
       expect(janitor.clean(p.outerHTML)).toBe('<p foo="true" bar="baz"></p>');
+    });
+
+    it('should allow all attributes for elements with catch-all whitelist', function () {
+      var span = document.createElement('span');
+      span.setAttribute('data-test', 'true');
+      span.setAttribute('title', 'test');
+      expect(janitor.clean(span.outerHTML)).toBe('<span data-test="true" title="test"></span>');
     });
 
     it('should remove elements not in the whitelist', function () {


### PR DESCRIPTION
Setting a tag to 'true' in the sanitizer whitelist object will pass any attribute through for that node. So, for example:

```js
var janitor = new HTMLJanitor({
	tags: {
		div: {'id': true, 'class': true}, a: {'href': true, 'target': '_blank'}, p: {}, span: true
	}
});
```

Will allow no attributes for `p` as per usual, but all attributes regardless of their value for `span`.