### PR TITLE
Testing: add Firefox as a test browser

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = function (config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: [ 'Chrome' ],
+    browsers: [ 'Chrome', 'Firefox' ],
 
     // If browser does not capture in given timeout [ms], kill it
     captureTimeout: 60000,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "karma-chrome-launcher": "~0.1.0",
     "karma-jasmine": "~0.1.3",
     "karma-phantomjs-launcher": "~0.1.0",
+    "karma-firefox-launcher": "~0.1",
     "karma-requirejs": "~0.2.0",
     "plumber": "~0.4.0",
     "plumber-all": "~0.4.0",

--- a/test/janitor.spec.js
+++ b/test/janitor.spec.js
@@ -30,7 +30,7 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
       p.setAttribute('foo', 'true');
       p.setAttribute('bar', 'baz');
       var cleanP = janitor.clean(p.outerHTML);
-      expect(cleanP).toMatch(/foo="true">/);
+      expect(cleanP).toMatch(/foo="true"/);
       expect(cleanP).toMatch(/bar="baz"/);
     });
 

--- a/test/janitor.spec.js
+++ b/test/janitor.spec.js
@@ -29,7 +29,9 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
       var p = document.createElement('p');
       p.setAttribute('foo', 'true');
       p.setAttribute('bar', 'baz');
-      expect(janitor.clean(p.outerHTML)).toBe('<p foo="true" bar="baz"></p>');
+      var cleanP = janitor.clean(p.outerHTML);
+      expect(cleanP).toMatch(/foo="true">/);
+      expect(cleanP).toMatch(/bar="baz"/);
     });
 
     it('should remove elements not in the whitelist', function () {


### PR DESCRIPTION
I wanted to add Firefox to the test suite to provide a bit more insight into how the functionality works across browsers. This should make it easier to merge some of the other pull requests 