### PR TITLE
Element attribute stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A configuration object.
 
 E.g. `{tags: { p:{}, a: { href: true} }}` would limit the valid HTML subset to just paragraphs and anchor tags, the anchor tags would only have the `href` attribute preserved.
 
+#### Blacklisting and whitelisting attributes
+
+You can set an element to be `true` to allow all attributes on an element and `false` to remove all attributes.
+
 ## Distribution
 
 Uses UMD for support in AMD and Common JS environments.

--- a/src/html-janitor.js
+++ b/src/html-janitor.js
@@ -13,6 +13,18 @@
    * @param {boolean} config.keepNestedBlockElements Default false.
    */
   function HTMLJanitor(config) {
+
+    var tagDefinitions = config['tags'];
+    var tags = Object.keys(tagDefinitions);
+
+    var validConfigValues = tags
+      .map(function(k) { return typeof(tagDefinitions[k]); })
+      .filter(function(type) { return type === 'object' || type === 'boolean'; });
+
+    if(validConfigValues.length !== tags.length) {
+      throw new Error("The configuration was invalid");
+    }
+
     this.config = config;
   }
 

--- a/src/html-janitor.js
+++ b/src/html-janitor.js
@@ -19,9 +19,9 @@
 
     var validConfigValues = tags
       .map(function(k) { return typeof(tagDefinitions[k]); })
-      .filter(function(type) { return type === 'object' || type === 'boolean'; });
+      .every(function(type) { return type === 'object' || type === 'boolean'; });
 
-    if(validConfigValues.length !== tags.length) {
+    if(!validConfigValues) {
       throw new Error("The configuration was invalid");
     }
 

--- a/src/html-janitor.js
+++ b/src/html-janitor.js
@@ -92,7 +92,7 @@
 
       // Drop tag entirely according to the whitelist *and* if the markup
       // is invalid.
-      if (!this.config.tags[nodeName] || isInvalid || (!this.config.keepNestedBlockElements && isNestedBlockElement)) {
+      if (this.config.tags[nodeName] === undefined || isInvalid || (!this.config.keepNestedBlockElements && isNestedBlockElement)) {
         // Do not keep the inner text of SCRIPT/STYLE elements.
         if (! (node.nodeName === 'SCRIPT' || node.nodeName === 'STYLE')) {
           while (node.childNodes.length > 0) {

--- a/src/html-janitor.js
+++ b/src/html-janitor.js
@@ -18,7 +18,7 @@
     var tags = Object.keys(tagDefinitions);
 
     var validConfigValues = tags
-      .map(function(k) { return typeof(tagDefinitions[k]); })
+      .map(function(k) { return typeof tagDefinitions[k]; })
       .every(function(type) { return type === 'object' || type === 'boolean'; });
 
     if(!validConfigValues) {

--- a/test/janitor.spec.js
+++ b/test/janitor.spec.js
@@ -20,7 +20,8 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
         ul: {},
         li: {},
         small: true,
-        div: {}
+        div: {},
+        figure: false
       }
 
 
@@ -163,6 +164,15 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
       expect(attributes.getNamedItem('title').name).toBe('title');
       expect(attributes.getNamedItem('title').value).toBe('test');
 
+    });
+
+    it('should remove an element if blacklisted', function() {
+        var el = document.createElement('figure');
+        el.setAttribute('class', 'test');
+
+        var output = janitor.clean(el.outerHTML);
+
+        expect(output).toBe('<figure></figure>');
     });
 
   });

--- a/test/janitor.spec.js
+++ b/test/janitor.spec.js
@@ -198,4 +198,18 @@ define([ 'html-janitor' ], function (HTMLJanitor) {
 
   });
 
+  describe('janitor with invalid configuration', function() {
+
+    var config = {
+      tags: {
+        strong: 53
+      }
+    };
+
+    it('should throw an Error on invalid configuration', function() {
+      expect(function() {new HTMLJanitor(config)}).toThrow(new Error('The configuration was invalid'));
+    });
+
+  });
+
 });


### PR DESCRIPTION
This change makes it possible to set a tag definition to be `false` to black-list all the attributes for an element.

It updates the readme and also throws an error if a tag definition is anything other than `boolean` or `object` 