### PR TITLE
Update createHTMLDocument to work with older IE

### DIFF
--- a/src/html-janitor.js
+++ b/src/html-janitor.js
@@ -40,7 +40,7 @@
   }
 
   HTMLJanitor.prototype.clean = function (html) {
-    const sandbox = document.implementation.createHTMLDocument();
+    const sandbox = document.implementation.createHTMLDocument('');
     const root = sandbox.createElement("div");
     root.innerHTML = html;
 


### PR DESCRIPTION
The current implementation of `createHTMLDocument('')` needs to be updated to be compatible with IE11.

https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument#Parameters

React implemented the same change https://github.com/facebook/react/pull/10921/files